### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ huajuan
 Imagine a picture!
 
 
-###安装
+### 安装
 ```console
 composer global require fxp/composer-asset-plugin 1.0
 composer create-project --prefer-dist --stability=dev callmez/huajuan huajuan
@@ -13,9 +13,9 @@ php yii app
 ```
 按照提示步骤安装完毕后  即可访问网站
 
-###交流
+### 交流
 
-####@callmez
+#### @callmez
  
 
 - Yii2中国交流群: `343188481`

--- a/tests/README.md
+++ b/tests/README.md
@@ -78,7 +78,7 @@ codecept run functional,unit --coverage-html --coverage-xml
 
 You can see code coverage output under the `tests/_output` directory.
 
-###Remote code coverage
+### Remote code coverage
 
 When you run your tests not in the same process where code coverage is collected, then you should uncomment `remote` option and its
 related options, to be able to collect code coverage correctly. To setup remote code coverage you should follow [instructions](http://codeception.com/docs/11-Codecoverage)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
